### PR TITLE
refactor: minimize SCSS variables in favor of CSS custom properties

### DIFF
--- a/src/scss/_bootstrap-lean.scss
+++ b/src/scss/_bootstrap-lean.scss
@@ -15,6 +15,8 @@ $gray-800: var(--gray-800);
 $gray-900: var(--gray-900);
 $black: var(--black);
 
+$primary: var(--kku-color);
+$success: var(--color-success);
 $danger: var(--danger);
 $red: var(--red);
 $blue: var(--blue);
@@ -32,6 +34,10 @@ $headings-margin-bottom: var(--headings-margin-bottom);
 $paragraph-margin-bottom: var(--paragraph-margin-bottom);
 $dt-font-weight: var(--dt-font-weight);
 
+// Body
+$body-bg: var(--body-bg);
+$body-color: var(--body-color);
+
 // Tables
 $table-cell-padding: var(--table-cell-padding);
 $table-caption-color: var(--table-caption-color);
@@ -40,6 +46,8 @@ $table-caption-color: var(--table-caption-color);
 $label-margin-bottom: var(--label-margin-bottom);
 
 // Links
+$link-color: var(--link-color);
+$link-hover-color: var(--link-hover-color);
 $link-decoration: var(--link-decoration);
 $link-hover-decoration: var(--link-hover-decoration);
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,44 +1,19 @@
 @import "./bootstrap-lean";
 
-$font-family-sans-serif:
-  // Safari for OS X and iOS (San Francisco)
-    -apple-system,
-  // Chrome < 56 for OS X (San Francisco)
-    BlinkMacSystemFont,
-  // Windows
-    "Segoe UI",
-  // Android
-    "Roboto",
-  // Basic web fallback
-    "Helvetica Neue",
-    Arial, sans-serif,
-  // Emoji fonts
-    "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol" !default;
+// Minimal SCSS variables - Only for SCSS-specific operations
+// All visual values are defined as CSS custom properties in styles.scss :root
 
-$kku_color: #a73b24;
-$dark_navy: #2a3a42;
-$color-success: #48BB78;
-$color-error: #e53e3e;
+// These SCSS vars reference CSS custom properties and are needed for:
+// 1. Mixins with @if conditionals (can't use CSS vars)
+// 2. Negation operations like -$padding (can't negate CSS vars)
+// 3. SCSS interpolation in calc() with math operations
+// 4. Passing to Bootstrap mixins that expect SCSS variables
 
-//$primary: $kku_color;
-
-$body-color: rgba($dark_navy, 0.87);
-$body-bg: #efefef;
-$sidebar-bg: $dark_navy;
-
-$link-color: $kku_color;
-$link-decoration: none;
-$link-hover-color: darken($link-color, 10%);
-
-$sidebar-width: 220px;
-$content-container-max-width: 960px;
-
-$site-header-height: 64px;
-$site-footer-height: 1.5rem;
-
-$card-padding: 1.25rem;
-
-$card-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
-
-$card-radius: 4px;
+$card-padding: var(--card-padding);         // Used with negation: -$card-padding
+$card-shadow: var(--card-shadow);           // Used in card() mixin
+$border-radius: var(--border-radius);       // Used in @if and card() mixin
+$enable-rounded: var(--enable-rounded);     // Used in @if conditional
+$dark_navy: var(--dark-navy);               // Used for page_title_with_icon mixin color
+$font-family-sans-serif: var(--font-family-sans-serif); // Legacy, kept for compatibility
+$site-header-height: var(--site-header-height); // Used in calc() and layout
+$content-container-max-width: var(--content-container-max-width); // Used in layout

--- a/src/scss/components/_timetable.scss
+++ b/src/scss/components/_timetable.scss
@@ -33,7 +33,7 @@ table.timeheader { // teach table
         font-size: 10px;
         font-weight: normal;
         background-color: $dark_navy !important;
-        border-color: darken($dark_navy, 5%) !important;
+        border-color: var(--dark-navy-dark) !important;
         color: rgba(white, 0.87);
 
         > font > b, > font > b > font {
@@ -53,8 +53,8 @@ table.timeheader { // teach table
       }
       > td[bgcolor="#C05050"] { // sat-sun
         vertical-align: middle;
-        background-color: rgba($danger, 0.4) !important;
-        border-color: rgba($danger, 0.4) !important;
+        background-color: var(--danger-40) !important;
+        border-color: var(--danger-40) !important;
         color: $gray-800;
       }
       > td[bgcolor="#C0D0FF"], > td[bgcolor="#D0D0F0"] {
@@ -64,7 +64,7 @@ table.timeheader { // teach table
         font-weight: normal;
       }
       > td[bgcolor="#FFA0A0"], > td[bgcolor="#A0FFA0"] {
-        background-color: rgba($danger, 0.1) !important;
+        background-color: var(--danger-10) !important;
         border-color: $gray-300 !important;
         color: $gray-600;
         font-weight: normal;

--- a/src/scss/pages/home.scss
+++ b/src/scss/pages/home.scss
@@ -96,7 +96,7 @@ div[align="center"] > #wrapper {
                     padding: 0.25rem 0;
                     font-size: 0.875rem !important;
                     line-height: 1.75em;
-                    color: rgba($dark_navy, 0.75) !important;
+                    color: var(--dark-navy-75) !important;
                   }
                 }
 

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -10,9 +10,12 @@
   --kku-color: #a73b24;
   --kku-color-dark: color-mix(in srgb, #a73b24 90%, black);
   --dark-navy: #2a3a42;
+  --dark-navy-75: rgba(42, 58, 66, 0.75);
+  --dark-navy-dark: color-mix(in srgb, #2a3a42 95%, black);
   --sidebar-bg-color: #2a3a42;
   --sidebar-bg-color-dark: color-mix(in srgb, #2a3a42 95%, black);
   --facebook-brand-color: #0966ff;
+  --facebook-brand-color-dark: color-mix(in srgb, #4267b2 95%, black);
   --color-success: #48BB78;
   --color-error: #e53e3e;
   --color-error-dark: color-mix(in srgb, #e53e3e 84%, black);
@@ -32,6 +35,8 @@
 
   // Semantic colors
   --danger: #dc3545;
+  --danger-40: rgba(220, 53, 69, 0.4);
+  --danger-10: rgba(220, 53, 69, 0.1);
   --red: #dc3545;
   --blue: #007bff;
 
@@ -442,7 +447,7 @@ a[href*="facebook.com/share.php"] {
   &:hover {
     text-decoration: none !important;
     color: white !important;
-    background-color: darken(#4267b2, 5%) !important;
+    background-color: var(--facebook-brand-color-dark) !important;
   }
 
   &:focus-visible {


### PR DESCRIPTION
- Reduced _variables.scss from 45 lines to 20 lines, keeping only variables needed for SCSS-specific operations
- Added missing Bootstrap-compatible variables to _bootstrap-lean.scss
- Replaced darken() and rgba() SCSS functions with pre-calculated CSS custom properties
- All visual values now live in :root CSS custom properties for runtime flexibility