### PR TITLE
fix: update manifest.json to reference bundled main.js

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
         "*://reg-mirror.kku.ac.th/*"
       ],
       "css": ["css/styles.css"],
-      "js": ["js/utils.js", "js/performance.js", "js/main.js"]
+      "js": ["js/main.js"]
     }, {
       "matches": [
         "*://reg.kku.ac.th/registrar/calendar.asp*",


### PR DESCRIPTION
- Removed references to utils.js and performance.js (now bundled into main.js)
- Fixes 'Could not load javascript' extension error